### PR TITLE
transaction journal id cause update api call get 404 error

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -17,6 +17,7 @@ Every time you add new transaction to FireFly III, either manually or via import
 - `git clone https://github.com/akopulko/ffiiitc.git`
 - `docker build -t ffiiitc:latest .`
 #### Run
+##### Docker Compose
 - Stop `docker compose -f docker-compose.yml down`
 - Modify your FireFly III docker compose file add the following
 ```yaml
@@ -29,11 +30,11 @@ Every time you add new transaction to FireFly III, either manually or via import
     container_name: ffiiitc
     environment:
       - FF_API_KEY=<YOUR_PAT_GOES_HERE>
-      - FF_APP_URL=http://app:8080
+      - FF_APP_URL=<FIREFLY_ADDRESS:PORT>
     volumes:
       - ffiiitc-data:/app/data
     ports:
-     - '8082:8080'
+     - '<EXPOSED_PORT>:8080'
     depends_on:
      - app
 volumes:
@@ -41,6 +42,17 @@ volumes:
    ffiiitc-data:
 ```
 - Start `docker compose -f docker-compose.yml up -d`
+
+#### Prue Docker
+```
+docker run
+  -d
+  --name='ffiiitc'
+  -e 'FF_API_KEY'='<YOUR_PAT_GOES_HERE>'
+  -e 'FF_APP_URL'='<FIREFLY_ADDRESS:PORT>'
+  -p '<EXPOSED_PORT>:8080'
+  -v '<TRAINED_MODEL_FOLDER>':'/app/data':'rw' 'safaqwqrfw/ffiiitc'
+```
 #### Configure Web Hooks in FireFly
 In `FireFly` go to `Automation -> Webhooks` and click `Create new webhook`
 - Create webhook for transaction classification
@@ -49,7 +61,7 @@ title: classify
 trigger: after transaction creation
 response: transaction details
 delivery: json
-url: http://fftc:8080
+url: http://fftc:<EXPOSED_PORT>/classify
 active: checked
 ```
 

--- a/Readme.md
+++ b/Readme.md
@@ -43,7 +43,7 @@ volumes:
 ```
 - Start `docker compose -f docker-compose.yml up -d`
 
-#### Prue Docker
+#### Docker
 ```
 docker run
   -d
@@ -51,7 +51,7 @@ docker run
   -e 'FF_API_KEY'='<YOUR_PAT_GOES_HERE>'
   -e 'FF_APP_URL'='<FIREFLY_ADDRESS:PORT>'
   -p '<EXPOSED_PORT>:8080'
-  -v '<TRAINED_MODEL_FOLDER>':'/app/data':'rw' 'safaqwqrfw/ffiiitc'
+  -v '<TRAINED_MODEL_FOLDER>':'/app/data':'rw' 'ffiiitc'
 ```
 #### Configure Web Hooks in FireFly
 In `FireFly` go to `Automation -> Webhooks` and click `Create new webhook`

--- a/internal/classifier/classifier.go
+++ b/internal/classifier/classifier.go
@@ -4,7 +4,8 @@ import (
 	"ffiiitc/internal/firefly"
 	"ffiiitc/internal/utils"
 	"fmt"
-
+	"os"
+    "time"
 	"github.com/go-pkgz/lgr"
 	"github.com/navossoc/bayesian"
 )
@@ -26,7 +27,8 @@ func NewTrnClassifier(fc *firefly.FireFlyHttpClient, l *lgr.Logger) *TrnClassifi
 
 	l.Logf("INFO trying to load classifier from %s", modelFile)
 	c, err := loadClassifierFromFile(modelFile)
-	if err != nil {
+	file, _ := os.Stat(modelFile)
+	if err != nil || time.Now().Sub(file.ModTime()) > 12*time.Hour{
 		l.Logf("ERROR loading classifier from file %s, %v", modelFile, err)
 		//log.Println("no model file found, need to do some training...")
 		l.Logf("INFO need to do some training...")

--- a/internal/firefly/firefly.go
+++ b/internal/firefly/firefly.go
@@ -35,6 +35,7 @@ type FireFlyTransaction struct {
 
 type FireFlyTransactions struct {
 	FireWebHooks bool                 `json:"fire_webhooks"`
+	Id           string                  `json:"id"`
 	Transactions []FireFlyTransaction `json:"transactions"`
 }
 
@@ -114,14 +115,15 @@ func (fc *FireFlyHttpClient) SendPutRequestWithToken(url, token string, data []b
 	return fc.sendRequestWithToken(http.MethodPut, url, token, data)
 }
 
-func (fc *FireFlyHttpClient) UpdateTransactionCategory(id, category string) error {
+func (fc *FireFlyHttpClient) UpdateTransactionCategory(id, trans_id, category string) error {
 	//log.Printf("updating transaction: %s", id)
 
 	trn := FireFlyTransactions{
 		FireWebHooks: false,
+		Id: id,
 		Transactions: []FireFlyTransaction{
 			{
-				TransactionID: id,
+				TransactionID: trans_id,
 				Category:      category,
 			},
 		},

--- a/internal/handlers/handler.go
+++ b/internal/handlers/handler.go
@@ -25,6 +25,7 @@ type FireflyTrn struct {
 }
 
 type FireFlyContent struct {
+	Id           int64  `json:"id"`
 	Transactions []FireflyTrn `json:"transactions"`
 }
 
@@ -62,16 +63,16 @@ func (wh *WebHookHandler) HandleNewTransactionWebHook(w http.ResponseWriter, r *
 	for _, trn := range hookData.Content.Transactions {
 		wh.Logger.Logf(
 			"INFO hook new trn: received (id: %v) (description: %s)",
-			trn.Id,
+			hookData.Content.Id,
 			trn.Description,
 		)
 		cat := wh.Classifier.ClassifyTransaction(trn.Description)
-		wh.Logger.Logf("INFO hook new trn: classified (id: %v) (category: %s)", trn.Id, cat)
-		err = wh.FireflyClient.UpdateTransactionCategory(strconv.FormatInt(trn.Id, 10), cat)
+		wh.Logger.Logf("INFO hook new trn: classified (id: %v) (category: %s)",  hookData.Content.Id, cat)
+		err = wh.FireflyClient.UpdateTransactionCategory(strconv.FormatInt( hookData.Content.Id, 10), strconv.FormatInt(trn.Id, 10), cat)
 		if err != nil {
-			wh.Logger.Logf("ERROR hook new trn: error updating (id: %v) %v", trn.Id, err)
+			wh.Logger.Logf("ERROR hook new trn: error updating (id: %v) %v",  hookData.Content.Id, err)
 		}
-		wh.Logger.Logf("INFO hook new trn: updated (id: %v)", trn.Id)
+		wh.Logger.Logf("INFO hook new trn: updated (id: %v)",  hookData.Content.Id)
 
 	}
 	w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
According to https://api-docs.firefly-iii.org/#/transactions/updateTransaction and https://api-docs.firefly-iii.org/#/transactions/storeTransaction

For a transaction json, it will have a structure like this

`data": {
        "type": "transactions",
        "id": "1231",
        "attributes": {
            "transactions": [
                {
                    "user": "1",
                    "transaction_journal_id": "1234",}]`

Where id and transaction_journal_id are not all way the same. And for API calls, id instead of transcation_journal_id is used to reference a transaction. Currently, ffiiitc's UpdateTransactionCategory and HandleNewTransactionWebHook use transaction_journal_id  for API call and return json data creation. This causes 404 error when id and transaction_journal_id  are miss matched when calling "api/v1/transactions/{transaction_journal_id}". And even when calling "api/v1/transactions/{id}", because the json data sent to FireFly is missing the id file, no transaction is updated. 

Changes:
1. change transaction update id from transaction journal id to transaction id according to FireFly API
2. in FireFlyContent add Id field to decode that from json.
3. For HandleNewTransactionWebHook, replace trn.Id(transcation_journal_id) with hookData.Content.Id(id)
4. For FireFlyTransactions add Id field to encode that to json
5. For UpdateTransactionCategory, add one additional argument for id, and add it to FireFlyTransactions.