### PR TITLE
Environment variable values stored in files

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ volumes:
    ffiiitc-data:
 ```
 
-You can also prepend your environment variable names with `_FILE` instead, having their value point to the file where tha actual sensitive value is stored. This works with any environment variable.
+You can also append your environment variable names with `_FILE` instead, having their value point to the file where tha actual sensitive value is stored. This works with any environment variable.
 
 ```yaml
 secrets:

--- a/README.md
+++ b/README.md
@@ -51,6 +51,39 @@ volumes:
    ffiiitc-data:
 ```
 
+You can also prepend your environment variable names with `_FILE` instead, having their value point to the file where tha actual sensitive value is stored. This works with any environment variable.
+
+```yaml
+secrets:
+  ffiiitc-personal-access-token:
+    file: "<path/to/secrets/location>/ffiiitc-personal-access-token"
+
+services:
+  ...
+  fftc:
+    image: akopulko/ffiiitc:latest
+    hostname: fftc
+    networks:
+      - firefly_iii
+    restart: always
+    container_name: ffiiitc
+    secrets:
+      - "ffiiitc-personal-access-token"
+    environment:
+      - FF_API_KEY_FILE="/run/secrets/ffiiitc-personal-access-token"
+      - FF_APP_URL=<FIREFLY_ADDRESS:PORT>
+    volumes:
+      - ffiiitc-data:/app/data
+    ports:
+      - '<EXPOSED_PORT>:8080'
+    depends_on:
+      - app
+
+volumes:
+  ...
+  ffiiitc-data:
+```
+
 - Start `docker compose -f docker-compose.yml up -d`
 
 #### Docker

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,12 +2,17 @@ package config
 
 import (
 	"errors"
+	"fmt"
 	"os"
+
+	"github.com/go-pkgz/lgr"
 )
 
 const (
 	FireflyAppTimeout = 10               // 10 sec for fftc to app service timeout
 	ModelFile         = "data/model.gob" //file name to store model
+	apiKeyEnvVar      = "FF_API_KEY"
+	appUrlEnvVar      = "FF_APP_URL"
 )
 
 type Config struct {
@@ -25,17 +30,61 @@ func EnvVarExist(varName string) bool {
 	return present
 }
 
-func NewConfig() (*Config, error) {
-	for _, val := range envVars {
-		exist := EnvVarExist(val)
-		if !exist {
-			return nil, errors.New("env variable is not set: " + val)
-		}
+func EnvVarIsSet(varName string) bool {
+	return os.Getenv(varName) != ""
+}
+
+func LookupEnvVarValueFromFile(path string, logger *lgr.Logger) (string, bool) {
+	if path == "" {
+		logger.Logf("WARN file path is empty!")
+		return "", false
+	}
+
+	logger.Logf("DEBUG reading file...")
+	value, e := os.ReadFile(path)
+
+	if e != nil {
+		panic(e)
+	}
+
+	return string(value), true
+}
+
+func LookupEnvVar(variableName string, logger *lgr.Logger) (string, bool) {
+	logger.Logf("DEBUG looking for env var %s", variableName)
+
+	// Try get value from a file, like Docker secrets.
+	if EnvVarIsSet(variableName + "_FILE") {
+		logger.Logf("DEBUG var %s is set as file, getting file path...", variableName)
+		path := os.Getenv(variableName + "_FILE")
+		logger.Logf("DEBUG file path is '%s'", path)
+		return LookupEnvVarValueFromFile(path, logger)
+	}
+
+	// Try get value ist stored in variable directly.
+	logger.Logf("DEBUG extracting value directly from env var")
+	return os.LookupEnv(variableName)
+}
+
+func FormatEnvNotSetErrorMessage(variableName string) string {
+	return fmt.Sprintf("Environment vars '%s' or '%s' not set!", variableName, variableName+"_FILE")
+}
+
+func NewConfig(logger *lgr.Logger) (*Config, error) {
+	apiKey, apiKeyExists := LookupEnvVar(apiKeyEnvVar, logger)
+
+	if !apiKeyExists {
+		return nil, errors.New(FormatEnvNotSetErrorMessage(apiKeyEnvVar))
+	}
+
+	appUrl, appUrlExists := LookupEnvVar(appUrlEnvVar, logger)
+	if !appUrlExists {
+		return nil, errors.New(FormatEnvNotSetErrorMessage(appUrlEnvVar))
 	}
 
 	cfg := Config{
-		APIKey: os.Getenv("FF_API_KEY"),
-		FFApp:  os.Getenv("FF_APP_URL"),
+		APIKey: apiKey,
+		FFApp:  appUrl,
 	}
 
 	return &cfg, nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/go-pkgz/lgr"
 )
@@ -41,11 +42,13 @@ func LookupEnvVarValueFromFile(path string, logger *lgr.Logger) (string, bool) {
 	}
 
 	logger.Logf("DEBUG reading file...")
-	value, e := os.ReadFile(path)
+	valueBytes, e := os.ReadFile(path)
 
 	if e != nil {
 		panic(e)
 	}
+	value := string(valueBytes)
+	value = strings.TrimSuffix(value, "\n")
 
 	return string(value), true
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,8 @@ package config
 import (
 	"os"
 	"testing"
+
+	"github.com/go-pkgz/lgr"
 )
 
 func TestEnvVarExist(t *testing.T) {
@@ -28,13 +30,16 @@ func TestEnvVarExist(t *testing.T) {
 }
 
 func TestNewConfig(t *testing.T) {
+	logger := lgr.New(lgr.Debug, lgr.CallerFunc)
+
 	t.Run("AllEnvVarsExist", func(t *testing.T) {
+
 		// Set up temporary environment variables for testing
 		os.Setenv("FF_API_KEY", "test_api_key")
 		os.Setenv("FF_APP_URL", "test_app_url")
 
 		// Create a new config
-		cfg, err := NewConfig()
+		cfg, err := NewConfig(logger)
 
 		// Check if there is no error
 		if err != nil {
@@ -56,7 +61,7 @@ func TestNewConfig(t *testing.T) {
 
 	t.Run("MissingEnvVars", func(t *testing.T) {
 		// Create a new config
-		cfg, err := NewConfig()
+		cfg, err := NewConfig(logger)
 
 		// Check if there is an error
 		if err == nil {

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ func main() {
 
 	// get the config
 	l.Logf("INFO getting config")
-	cfg, err := config.NewConfig()
+	cfg, err := config.NewConfig(l)
 	if err != nil {
 		l.Logf("FATAL getting config: %v", err)
 	}


### PR DESCRIPTION
This adds the option to store environment variable values in files, e.g. for sensitive information like the API-Key. You can now append your environment variable names with `_FILE` instead, having their value point to the file where tha actual sensitive value is stored. This works with any environment variable. This makes managing compose files with Docker a lot easier.

```yaml
secrets:
  ffiiitc-personal-access-token:
    file: "<path/to/secrets/location>/ffiiitc-personal-access-token"

services:
  ...
  fftc:
    image: akopulko/ffiiitc:latest
    hostname: fftc
    networks:
      - firefly_iii
    restart: always
    container_name: ffiiitc
    secrets:
      - "ffiiitc-personal-access-token"
    environment:
      - FF_API_KEY_FILE="/run/secrets/ffiiitc-personal-access-token"
      - FF_APP_URL=<FIREFLY_ADDRESS:PORT>
    volumes:
      - ffiiitc-data:/app/data
    ports:
      - '<EXPOSED_PORT>:8080'
    depends_on:
      - app

volumes:
  ...
  ffiiitc-data:
```
