### PR TITLE
fix: api-calls redirect to login

### DIFF
--- a/internal/firefly/firefly.go
+++ b/internal/firefly/firefly.go
@@ -86,6 +86,7 @@ func (fc *FireFlyHttpClient) sendRequestWithToken(method, url, token string, dat
 	// Set the Authorization header with the Bearer token.
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("accept", "application/vnd.api+json")
 
 	resp, err := client.Do(req)
 	if err != nil {


### PR DESCRIPTION
I had the problem that ffiiitc always failed on start. The logs of firefly3 showed that it redirects to the login page.

When setting this header, the API is accessed correctly. I'm not quite sure since when this is necessary, but maybe this helps someone.