### PR TITLE
date range for model training

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,4 +122,12 @@ You can check `ffiiitc` logs to see if there are any errors:<br> `docker compose
 There is also option available to force train the model from your transactions if required. 
 To trigger force train run the following command and restart `fftc` container:
 `curl -i http://localhost:<EXPOSED_PORT>/train` where `EXPOSED_PORT` is the port you provided in your docker compose for `fftc`. 
-As always, you can check logs to see if model was successfully regenerated. 
+As always, you can check logs to see if model was successfully regenerated.
+
+You can also provide optional `start` and `end` date query parameters (in `yyyy-mm-dd` format) to limit the transactions used for training. For example:
+
+```
+curl -i "http://localhost:<EXPOSED_PORT>/train?start=2024-01-01&end=2024-06-01"
+```
+
+If `start` and/or `end` are omitted, all available transactions will be used for training.

--- a/internal/handlers/handler.go
+++ b/internal/handlers/handler.go
@@ -84,15 +84,19 @@ func (wh *WebHookHandler) HandleNewTransactionWebHook(w http.ResponseWriter, r *
 // http handler for forcing to train model
 func (wh *WebHookHandler) HandleForceTrainingModel(w http.ResponseWriter, r *http.Request) {
 
-	// only allow post method
+	// only allow get method
 	if r.Method != http.MethodGet {
 		http.Error(w, "bad request", http.StatusBadRequest)
 		return
 	}
 
+	query := r.URL.Query()
+	startStr := query.Get("start")
+	endStr := query.Get("end")
+
 	wh.Logger.Logf("INFO Received request to perform force training")
 	wh.Logger.Logf("INFO Requesting transactions data from Firefly")
-	trnDataset, err := wh.FireflyClient.GetTransactionsDataset()
+	trnDataset, err := wh.FireflyClient.GetTransactionsDataset(startStr, endStr)
 	if err != nil || len(trnDataset) == 0 {
 		wh.Logger.Logf("ERROR: Error while getting transactions data\n %v", err)
 	} else {

--- a/main.go
+++ b/main.go
@@ -37,7 +37,8 @@ func main() {
 		l.Logf("INFO looks like we need to do some training...")
 		// get transactions in data set
 		//[ [cat, trn description], [cat, trn description]... ]
-		trnDataset, err := fc.GetTransactionsDataset()
+		// Empty string for start and end date means all transactions
+		trnDataset, err := fc.GetTransactionsDataset("", "")
 		l.Logf("DEBUG data set:\n %v", trnDataset)
 
 		if err != nil {


### PR DESCRIPTION
provide optional `start` and `end` date query parameters (in `yyyy-mm-dd` format) to limit the transactions used for training. For example:

```
curl -i "http://localhost:<EXPOSED_PORT>/train?start=2024-01-01&end=2024-06-01"
```

If `start` and/or `end` are omitted, all available transactions will be used for training.